### PR TITLE
fix: Windows Unicode Encode error

### DIFF
--- a/src/utils/model_loader.py
+++ b/src/utils/model_loader.py
@@ -255,7 +255,7 @@ def download_all_models():
     for model_name in MODEL_NAMES:
         try:
             path = get_model_path(model_name)
-            print(f"  ✓ {model_name}")
+            print(f"  [OK] {model_name}")
         except Exception as e:
-            print(f"  ✗ {model_name}: {e}")
+            print(f"  [FAIL] {model_name}: {e}")
     print("Done!")


### PR DESCRIPTION
## Summary
- Windows cp1252 인코딩에서 유니코드 문자(✓, ✗) 출력 시 발생하는 `UnicodeEncodeError` 수정
- ASCII 문자(`[OK]`, `[FAIL]`)로 대체

## Test plan
- [x] GitHub Actions 빌드 테스트 통과 확인 (Linux, macOS, Windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)